### PR TITLE
Screens use render targets

### DIFF
--- a/Monogame-RPG-Engine/src/App/Main/ScreenCoordinator.cs
+++ b/Monogame-RPG-Engine/src/App/Main/ScreenCoordinator.cs
@@ -23,6 +23,7 @@ namespace App.Main
         {
             GameState = GameState.MENU;
             previousGameState = GameState;
+            UseRenderTarget = false;
             UpdateCurrentScreen();
         }
 
@@ -65,9 +66,9 @@ namespace App.Main
             currentScreen.LoadContent();
         }
 
-        public override void Draw(GraphicsHandler graphicsHandler)
+        protected override void Draw(GraphicsHandler graphicsHandler)
         {
-            currentScreen.Draw(graphicsHandler);
+            currentScreen.Render(graphicsHandler);
         }
     }
 }

--- a/Monogame-RPG-Engine/src/App/Maps/TestMap.cs
+++ b/Monogame-RPG-Engine/src/App/Maps/TestMap.cs
@@ -21,8 +21,8 @@ namespace App.Maps
     public class TestMap : Map
     {
 
-        public TestMap(ContentLoader contentLoader)
-            : base("test_map.txt", new CommonTileset(contentLoader), contentLoader)
+        public TestMap(int cameraWidth, int cameraHeight, ContentLoader contentLoader)
+            : base("test_map.txt", new CommonTileset(contentLoader), cameraWidth, cameraHeight, contentLoader)
         {
             PlayerStartPosition = GetMapTile(17, 20).Location;
         }

--- a/Monogame-RPG-Engine/src/App/Maps/TitleScreenMap.cs
+++ b/Monogame-RPG-Engine/src/App/Maps/TitleScreenMap.cs
@@ -18,8 +18,8 @@ namespace App.Maps
     {
         private Sprite cat;
 
-        public TitleScreenMap(ContentLoader contentLoader)
-            : base("title_screen_map.txt", new CommonTileset(contentLoader), contentLoader)
+        public TitleScreenMap(int cameraWidth, int cameraHeight, ContentLoader contentLoader)
+            : base("title_screen_map.txt", new CommonTileset(contentLoader), cameraWidth, cameraHeight, contentLoader)
         {
             Point catLocation = GetMapTile(8, 5).Location.SubtractX(6).SubtractY(7);
             cat = new Sprite(new SpriteSheet(contentLoader.LoadTexture(GraphicsHelper.CAT), 24, 24).GetSprite(0, 0));

--- a/Monogame-RPG-Engine/src/App/Screens/CreditsScreen.cs
+++ b/Monogame-RPG-Engine/src/App/Screens/CreditsScreen.cs
@@ -64,7 +64,7 @@ namespace App.Screens
             }
         }
 
-        public override void Draw(GraphicsHandler graphicsHandler)
+        protected override void Draw(GraphicsHandler graphicsHandler)
         {
             background.Draw(graphicsHandler);
             creditsLabel.Draw(graphicsHandler);

--- a/Monogame-RPG-Engine/src/App/Screens/CreditsScreen.cs
+++ b/Monogame-RPG-Engine/src/App/Screens/CreditsScreen.cs
@@ -36,7 +36,7 @@ namespace App.Screens
 
         public override void Initialize()
         {
-            background = new TitleScreenMap(ContentLoader);
+            background = new TitleScreenMap(ScreenWidth, ScreenHeight, ContentLoader);
             background.AdjustCamera = false;
             keyLocker.LockKey(Keys.Space);
 

--- a/Monogame-RPG-Engine/src/App/Screens/MenuScreen.cs
+++ b/Monogame-RPG-Engine/src/App/Screens/MenuScreen.cs
@@ -140,7 +140,7 @@ namespace App.Screens
             }
         }
 
-        public override void Draw(GraphicsHandler graphicsHandler)
+        protected override void Draw(GraphicsHandler graphicsHandler)
         {
             background.Draw(graphicsHandler);
             playGame.Draw(graphicsHandler);

--- a/Monogame-RPG-Engine/src/App/Screens/MenuScreen.cs
+++ b/Monogame-RPG-Engine/src/App/Screens/MenuScreen.cs
@@ -42,7 +42,7 @@ namespace App.Screens
 
         public override void Initialize()
         {
-            background = new TitleScreenMap(ContentLoader);
+            background = new TitleScreenMap(ScreenWidth, ScreenHeight, ContentLoader);
             background.AdjustCamera = false;
             keyPressTimer = 0;
             menuItemSelected = -1;

--- a/Monogame-RPG-Engine/src/App/Screens/PlayLevelScreen.cs
+++ b/Monogame-RPG-Engine/src/App/Screens/PlayLevelScreen.cs
@@ -93,7 +93,7 @@ namespace App.Screens
             }
         }
 
-        public override void Draw(GraphicsHandler graphicsHandler)
+        protected override void Draw(GraphicsHandler graphicsHandler)
         {
             // based on screen state, draw appropriate graphics
             switch (PlayLevelScreenState)
@@ -106,7 +106,7 @@ namespace App.Screens
                     }
                     break;
                 case PlayLevelScreenStates.LEVEL_COMPLETED:
-                    winScreen.Draw(graphicsHandler);
+                    winScreen.Render(graphicsHandler);
                     break;
             }
         }

--- a/Monogame-RPG-Engine/src/App/Screens/PlayLevelScreen.cs
+++ b/Monogame-RPG-Engine/src/App/Screens/PlayLevelScreen.cs
@@ -45,7 +45,7 @@ namespace App.Screens
             flagManager.AddFlag("hasFoundBall", false);
 
             // define/setup map
-            map = new TestMap(ContentLoader);
+            map = new TestMap(ScreenWidth, ScreenHeight, ContentLoader);
             map.FlagManager = flagManager;
 
             // setup player

--- a/Monogame-RPG-Engine/src/App/Screens/WinScreen.cs
+++ b/Monogame-RPG-Engine/src/App/Screens/WinScreen.cs
@@ -62,9 +62,9 @@ namespace App.Screens
             }
         }
 
-        public override void Draw(GraphicsHandler graphicsHandler)
+        protected override void Draw(GraphicsHandler graphicsHandler)
         {
-            graphicsHandler.DrawFilledRectangle(0, 0, ScreenManager.ScreenWidth, ScreenManager.ScreenHeight, Color.Black);
+            graphicsHandler.DrawFilledRectangle(0, 0, ScreenManager.WindowWidth, ScreenManager.WindowHeight, Color.Black);
             winMessage.Draw(graphicsHandler);
             instructions.Draw(graphicsHandler);
         }

--- a/Monogame-RPG-Engine/src/Engine/Core/DefaultScreen.cs
+++ b/Monogame-RPG-Engine/src/Engine/Core/DefaultScreen.cs
@@ -19,6 +19,6 @@ namespace Engine.Core
 
         public override void Update(GameTime gameTime, KeyboardState keyboardState) { }
 
-        public override void Draw(GraphicsHandler graphicsHandler) { }
+        protected override void Draw(GraphicsHandler graphicsHandler) { }
     }
 }

--- a/Monogame-RPG-Engine/src/Engine/Core/GameLoop.cs
+++ b/Monogame-RPG-Engine/src/Engine/Core/GameLoop.cs
@@ -16,11 +16,12 @@ namespace Engine.Core
 {
     public class GameLoop : Game
     {
-        private GraphicsDeviceManager graphics;
+        private GraphicsDeviceManager graphicsDeviceManager;
         private SpriteBatch spriteBatch;
         private GraphicsHandler graphicsHandler;
         public ScreenManager ScreenManager { get; private set; }
         public static GraphicsDeviceManager GraphicsDeviceManager { get; private set; }
+        public static GraphicsDevice GraphicsDeviceInstance { get; private set; }
         public static ContentManager ContentManager { get; private set; }
         public static GameServiceContainer GameServiceContainer { get; private set; }
         public static int ViewportWidth { get; private set; }
@@ -35,8 +36,8 @@ namespace Engine.Core
 
         public GameLoop()
         {
-            graphics = new GraphicsDeviceManager(this);
-            GraphicsDeviceManager = graphics;
+            graphicsDeviceManager = new GraphicsDeviceManager(this);
+            GraphicsDeviceManager = graphicsDeviceManager;
 
             // holding on to these graphics settings in the hopes I can figure out how to best utilize them later on, but right now they make the game choppy
             // graphics.PreferMultiSampling = true;
@@ -48,9 +49,9 @@ namespace Engine.Core
             TargetElapsedTime = TimeSpan.FromMilliseconds(1000.0f / Config.FPS);
             ContentManager = Content;
             GameServiceContainer = Services;
-            graphics.PreferredBackBufferWidth = Config.GAME_WINDOW_WIDTH;  // set this value to the desired width of your window
-            graphics.PreferredBackBufferHeight = Config.GAME_WINDOW_HEIGHT;   // set this value to the desired height of your window
-            graphics.ApplyChanges();
+            graphicsDeviceManager.PreferredBackBufferWidth = Config.GAME_WINDOW_WIDTH;  // set this value to the desired width of your window
+            graphicsDeviceManager.PreferredBackBufferHeight = Config.GAME_WINDOW_HEIGHT;   // set this value to the desired height of your window
+            graphicsDeviceManager.ApplyChanges();
             ViewportWidth = GraphicsDevice.Viewport.Width;
             ViewportHeight = GraphicsDevice.Viewport.Height;
 
@@ -59,6 +60,7 @@ namespace Engine.Core
             // this.Window.ClientSizeChanged += new EventHandler<EventArgs>(Window_ClientSizeChanged);
             
             GameWindow = Window;
+            GraphicsDeviceInstance = GraphicsDevice;
 
             ScreenManager = new ScreenManager();
             ScreenManager.Initialize(new Rectangle(0, 0, Config.GAME_WINDOW_WIDTH, Config.GAME_WINDOW_HEIGHT));
@@ -71,6 +73,7 @@ namespace Engine.Core
         protected override void Initialize()
         {
             spriteBatch = new SpriteBatch(GraphicsDevice);
+
             graphicsHandler = new GraphicsHandler(GraphicsDevice, spriteBatch);
 
             renderTarget = new RenderTarget2D(

--- a/Monogame-RPG-Engine/src/Engine/Core/GraphicsHandler.cs
+++ b/Monogame-RPG-Engine/src/Engine/Core/GraphicsHandler.cs
@@ -6,6 +6,7 @@ using MonoGame.Extended.BitmapFonts;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Engine.Core
 {
@@ -15,12 +16,15 @@ namespace Engine.Core
         public GraphicsDevice GraphicsDevice { get; private set; }
         public SpriteBatch SpriteBatch { get; private set; }
         private Rectangle currentViewportScissorRectangle;
+        private RenderTarget2D currentRenderTarget;
+        private Stack<RenderTargetBinding> previousRenderTargets;
 
         public GraphicsHandler(GraphicsDevice graphicsDevice, SpriteBatch spriteBatch)
         {
             GraphicsDevice = graphicsDevice;
             SpriteBatch = spriteBatch;
             currentViewportScissorRectangle = SpriteBatch.GraphicsDevice.ScissorRectangle;
+            previousRenderTargets = new Stack<RenderTargetBinding>();
         }
 
         public void DrawRectangle(int x, int y, int width, int height, Color color, int borderThickness = 1)
@@ -247,6 +251,58 @@ namespace Engine.Core
             SpriteBatch.End();
             SpriteBatch.GraphicsDevice.ScissorRectangle = currentViewportScissorRectangle;
             SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullCounterClockwise);
+        }
+
+        public void SetRenderTarget(int width, int height)
+        {
+            SpriteBatch.End();
+            RenderTarget2D renderTarget = new RenderTarget2D(GraphicsDevice, width, height);
+            SetRenderTarget(renderTarget);
+        }
+
+        public void SetRenderTarget(RenderTarget2D renderTarget)
+        {
+            SpriteBatch.End();
+            currentRenderTarget = renderTarget;
+            if (GraphicsDevice.GetRenderTargets().Length > 0 && GraphicsDevice.GetRenderTargets()[0].RenderTarget != null)
+            {
+                previousRenderTargets.Push(GraphicsDevice.GetRenderTargets()[0]);
+
+            }
+            SpriteBatch.GraphicsDevice.SetRenderTarget(renderTarget);
+            SpriteBatch.GraphicsDevice.Clear(Color.CornflowerBlue);
+            SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullCounterClockwise);
+        }
+
+        public void DrawRenderTarget(int x, int y, Color? color = null)
+        {
+            if (color == null)
+            {
+                color = Color.White;
+            }
+            SpriteBatch.End();
+
+            if (previousRenderTargets.Count > 0 && previousRenderTargets.Peek().RenderTarget != null)
+            {
+                SpriteBatch.GraphicsDevice.SetRenderTarget(previousRenderTargets.Peek().RenderTarget as RenderTarget2D);
+            }
+            else
+            {
+                // If no previous render target, reset to the default back buffer
+                SpriteBatch.GraphicsDevice.SetRenderTarget(null);
+            }
+
+            SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullCounterClockwise);
+            SpriteBatch.Draw(currentRenderTarget, new Vector2(x, y), color.Value);
+
+            if (previousRenderTargets.Count > 0 && previousRenderTargets.Peek().RenderTarget != null)
+            {
+                currentRenderTarget = previousRenderTargets.Pop().RenderTarget as RenderTarget2D;
+            }
+            else
+            {
+                currentRenderTarget = null;
+            }
         }
     }
 

--- a/Monogame-RPG-Engine/src/Engine/Core/GraphicsHandler.cs
+++ b/Monogame-RPG-Engine/src/Engine/Core/GraphicsHandler.cs
@@ -260,17 +260,27 @@ namespace Engine.Core
             SetRenderTarget(renderTarget);
         }
 
+        // creates a render target that all future content will be drawn to until DrawRenderTarget method is eventually called
+        // when DrawRenderTarget method is called, the entire render target will be drawn to the previous render target that was in use prior to this method being called
         public void SetRenderTarget(RenderTarget2D renderTarget)
         {
             SpriteBatch.End();
+
+            // set currentRenderTarget reference to the new render target
             currentRenderTarget = renderTarget;
+
+            // save existing render target if exists
             if (GraphicsDevice.GetRenderTargets().Length > 0 && GraphicsDevice.GetRenderTargets()[0].RenderTarget != null)
             {
                 previousRenderTargets.Push(GraphicsDevice.GetRenderTargets()[0]);
 
             }
+
+            // set new render target
             SpriteBatch.GraphicsDevice.SetRenderTarget(renderTarget);
             SpriteBatch.GraphicsDevice.Clear(Color.CornflowerBlue);
+
+            // start new spritebatch with new render target
             SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullCounterClockwise);
         }
 
@@ -282,6 +292,8 @@ namespace Engine.Core
             }
             SpriteBatch.End();
 
+            // if there is a previous render target that was in use prior to SetRenderTarget being called, restore it
+            // this will ensure the new render target is drawn on top of whatever was there prior
             if (previousRenderTargets.Count > 0 && previousRenderTargets.Peek().RenderTarget != null)
             {
                 SpriteBatch.GraphicsDevice.SetRenderTarget(previousRenderTargets.Peek().RenderTarget as RenderTarget2D);
@@ -292,9 +304,12 @@ namespace Engine.Core
                 SpriteBatch.GraphicsDevice.SetRenderTarget(null);
             }
 
+            // draw render target on top of previous render target
             SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullCounterClockwise);
             SpriteBatch.Draw(currentRenderTarget, new Vector2(x, y), color.Value);
 
+            // reset currentRenderTarget reference to the previous render target (if exists)
+            // this will ensure that if this was a situation where a render target was being drawn on another render target, that previous render target can now "continue" on like normal
             if (previousRenderTargets.Count > 0 && previousRenderTargets.Peek().RenderTarget != null)
             {
                 currentRenderTarget = previousRenderTargets.Pop().RenderTarget as RenderTarget2D;

--- a/Monogame-RPG-Engine/src/Engine/Core/Screen.cs
+++ b/Monogame-RPG-Engine/src/Engine/Core/Screen.cs
@@ -12,9 +12,11 @@ namespace Engine.Core
     {
         // each individual screen has access to its own content loader
         public ContentLoader ContentLoader { get; private set; }
+
+        // screen render target instance
         private RenderTarget2D renderTarget;
 
-        // bounds of screen
+        // bounds of screen for render target
         public int ScreenX { get; set; }
         public int ScreenY { get; set; }
         private int screenWidth = 1;
@@ -79,6 +81,7 @@ namespace Engine.Core
             }
         }
 
+        // create a new render target using screen bounds
         public void CreateRenderTarget()
         {
             renderTarget = new RenderTarget2D(GameLoop.GraphicsDeviceInstance, ScreenWidth, ScreenHeight);
@@ -99,6 +102,8 @@ namespace Engine.Core
         {
             ContentLoader = ContentLoader.Create();
             SetScreenBounds(0, 0, ScreenManager.WindowWidth, ScreenManager.WindowHeight);
+
+            // this allows for a subclass to override Draw while still ensuring the render target logic will be enforced in the Render method
             DrawReference = Draw;
         }
 
@@ -119,6 +124,7 @@ namespace Engine.Core
 
         private Action<GraphicsHandler> DrawReference = (graphicsHandler) => { };
 
+        // if render target is in use, it sets the render target first, then draws the screen's content to that render target, and then draws the entire render target
         public void Render(GraphicsHandler graphicsHandler) 
         {
             if (useRenderTarget)

--- a/Monogame-RPG-Engine/src/Engine/Core/Screen.cs
+++ b/Monogame-RPG-Engine/src/Engine/Core/Screen.cs
@@ -84,7 +84,7 @@ namespace Engine.Core
             renderTarget = new RenderTarget2D(GameLoop.GraphicsDeviceInstance, ScreenWidth, ScreenHeight);
         }
 
-        public void SetBounds(int x, int y, int width, int height)
+        public void SetScreenBounds(int x, int y, int width, int height)
         {
             ScreenX = x;
             ScreenY = y;
@@ -98,7 +98,7 @@ namespace Engine.Core
         public Screen()
         {
             ContentLoader = ContentLoader.Create();
-            SetBounds(0, 0, ScreenManager.WindowWidth, ScreenManager.WindowHeight);
+            SetScreenBounds(0, 0, ScreenManager.WindowWidth, ScreenManager.WindowHeight);
             DrawReference = Draw;
         }
 

--- a/Monogame-RPG-Engine/src/Engine/Core/Screen.cs
+++ b/Monogame-RPG-Engine/src/Engine/Core/Screen.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,85 @@ namespace Engine.Core
     {
         // each individual screen has access to its own content loader
         public ContentLoader ContentLoader { get; private set; }
+        private RenderTarget2D renderTarget;
+
+        // bounds of screen
+        public int X { get; set; }
+        public int Y { get; set; }
+        private int width = 1;
+        public int Width
+        {
+            get
+            {
+                return width;
+            }
+            set
+            {
+                if (width > 0)
+                {
+                    width = value;
+                    CreateRenderTarget();
+                }
+            }
+        }
+        private int height = 1;
+        public int Height
+        {
+            get
+            {
+                return height;
+            }
+            set
+            {
+                if (height > 0)
+                {
+                    height = value;
+                    CreateRenderTarget();
+                }
+            }
+        }
+
+        public Rectangle Bounds
+        {
+            get
+            {
+                return new Rectangle(X, Y, Width, Height);
+            }
+        }
+
+        private bool useRenderTarget = true;
+        public bool UseRenderTarget
+        {
+            get
+            {
+                return useRenderTarget;
+            }
+            set
+            {
+                useRenderTarget = value;
+                if (useRenderTarget)
+                {
+                    CreateRenderTarget();
+                }
+                else
+                {
+                    renderTarget = null;
+                }
+            }
+        }
+
+        public void CreateRenderTarget()
+        {
+            renderTarget = new RenderTarget2D(GameLoop.GraphicsDeviceInstance, Width, Height);
+        }
+
+        public void SetBounds(int x, int y, int width, int height)
+        {
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
+        }
 
         // all screens share this global content loader for content that is designed to be used everywhere
         public static ContentLoader GlobalContentLoader;
@@ -18,6 +98,8 @@ namespace Engine.Core
         public Screen()
         {
             ContentLoader = ContentLoader.Create();
+            SetBounds(0, 0, ScreenManager.WindowWidth, ScreenManager.WindowHeight);
+            DrawReference = Draw;
         }
 
         static Screen()
@@ -32,7 +114,24 @@ namespace Engine.Core
             ContentLoader.Unload();
         }
         public virtual void Update(GameTime gameTime, KeyboardState keyboardState) { }
-        public virtual void Draw(GraphicsHandler graphicsHandler) { }
+
+        protected virtual void Draw(GraphicsHandler graphicsHandler) { }
+
+        private Action<GraphicsHandler> DrawReference = (graphicsHandler) => { };
+
+        public void Render(GraphicsHandler graphicsHandler) 
+        {
+            if (useRenderTarget)
+            {
+                graphicsHandler.SetRenderTarget(renderTarget);
+                DrawReference.Invoke(graphicsHandler);
+                graphicsHandler.DrawRenderTarget(X, Y);
+            }
+            else
+            {
+                DrawReference.Invoke(graphicsHandler);
+            }
+        }
 
         // warning: if you need to call this, you likely have an asset loaded globally that shouldn't be
         public static void UnloadGlobalContent()

--- a/Monogame-RPG-Engine/src/Engine/Core/Screen.cs
+++ b/Monogame-RPG-Engine/src/Engine/Core/Screen.cs
@@ -15,46 +15,46 @@ namespace Engine.Core
         private RenderTarget2D renderTarget;
 
         // bounds of screen
-        public int X { get; set; }
-        public int Y { get; set; }
-        private int width = 1;
-        public int Width
+        public int ScreenX { get; set; }
+        public int ScreenY { get; set; }
+        private int screenWidth = 1;
+        public int ScreenWidth
         {
             get
             {
-                return width;
+                return screenWidth;
             }
             set
             {
-                if (width > 0)
+                if (screenWidth > 0)
                 {
-                    width = value;
+                    screenWidth = value;
                     CreateRenderTarget();
                 }
             }
         }
-        private int height = 1;
-        public int Height
+        private int screenHeight = 1;
+        public int ScreenHeight
         {
             get
             {
-                return height;
+                return screenHeight;
             }
             set
             {
-                if (height > 0)
+                if (screenHeight > 0)
                 {
-                    height = value;
+                    screenHeight = value;
                     CreateRenderTarget();
                 }
             }
         }
 
-        public Rectangle Bounds
+        public Rectangle ScreenBounds
         {
             get
             {
-                return new Rectangle(X, Y, Width, Height);
+                return new Rectangle(ScreenX, ScreenY, ScreenWidth, ScreenHeight);
             }
         }
 
@@ -81,15 +81,15 @@ namespace Engine.Core
 
         public void CreateRenderTarget()
         {
-            renderTarget = new RenderTarget2D(GameLoop.GraphicsDeviceInstance, Width, Height);
+            renderTarget = new RenderTarget2D(GameLoop.GraphicsDeviceInstance, ScreenWidth, ScreenHeight);
         }
 
         public void SetBounds(int x, int y, int width, int height)
         {
-            X = x;
-            Y = y;
-            Width = width;
-            Height = height;
+            ScreenX = x;
+            ScreenY = y;
+            ScreenWidth = width;
+            ScreenHeight = height;
         }
 
         // all screens share this global content loader for content that is designed to be used everywhere
@@ -125,7 +125,7 @@ namespace Engine.Core
             {
                 graphicsHandler.SetRenderTarget(renderTarget);
                 DrawReference.Invoke(graphicsHandler);
-                graphicsHandler.DrawRenderTarget(X, Y);
+                graphicsHandler.DrawRenderTarget(ScreenX, ScreenY);
             }
             else
             {

--- a/Monogame-RPG-Engine/src/Engine/Core/ScreenManager.cs
+++ b/Monogame-RPG-Engine/src/Engine/Core/ScreenManager.cs
@@ -17,29 +17,29 @@ namespace Engine.Core
         private Screen currentScreen;
 
         // gets bounds of currentScreen -- can be called from anywhere in an application
-        public static Rectangle ScreenBounds { get; private set; } = new Rectangle(0, 0, 0, 0);
+        public static Rectangle WindowBounds { get; private set; } = new Rectangle(0, 0, 0, 0);
 
         // gets width of currentScreen -- can be called from anywhere in an application
-        public static int ScreenWidth
+        public static int WindowWidth
         {
             get
             {
-                return ScreenBounds.Width;
+                return WindowBounds.Width;
             }
         }
 
         // gets height of currentScreen -- can be called from anywhere in an application
-        public static int ScreenHeight
+        public static int WindowHeight
         {
             get
             {
-                return ScreenBounds.Height;
+                return WindowBounds.Height;
             }
         }
 
         public void Initialize(Rectangle screenBounds)
         {
-            ScreenBounds = screenBounds;
+            WindowBounds = screenBounds;
             SetCurrentScreen(new DefaultScreen());
         }
 
@@ -57,7 +57,7 @@ namespace Engine.Core
 
         public void Draw(GraphicsHandler graphicsHandler)
         {
-            currentScreen.Draw(graphicsHandler);
+            currentScreen.Render(graphicsHandler);
         }
     }
 }

--- a/Monogame-RPG-Engine/src/Engine/Scene/MapCore/Camera.cs
+++ b/Monogame-RPG-Engine/src/Engine/Scene/MapCore/Camera.cs
@@ -52,13 +52,13 @@ namespace Engine.Scene.MapCore
         }
 
         public Camera(int startX, int startY, int tileWidth, int tileHeight, Map map)
-            : base(startX, startY, ScreenManager.ScreenWidth / tileWidth, ScreenManager.ScreenHeight / tileHeight)
+            : base(startX, startY, ScreenManager.WindowWidth / tileWidth, ScreenManager.WindowHeight / tileHeight)
         {
             this.map = map;
             this.tileWidth = tileWidth;
             this.tileHeight = tileHeight;
-            this.leftoverSpaceX = ScreenManager.ScreenWidth % this.tileWidth;
-            this.leftoverSpaceY = ScreenManager.ScreenHeight % this.tileHeight;
+            this.leftoverSpaceX = ScreenManager.WindowWidth % this.tileWidth;
+            this.leftoverSpaceY = ScreenManager.WindowHeight % this.tileHeight;
             ActiveEnhancedMapTiles = new List<EnhancedMapTile>();
             ActiveNPCs = new List<NPC>();
             ActiveTriggers = new List<Trigger>();

--- a/Monogame-RPG-Engine/src/Engine/Scene/MapCore/Camera.cs
+++ b/Monogame-RPG-Engine/src/Engine/Scene/MapCore/Camera.cs
@@ -51,14 +51,14 @@ namespace Engine.Scene.MapCore
             }
         }
 
-        public Camera(int startX, int startY, int tileWidth, int tileHeight, Map map)
-            : base(startX, startY, ScreenManager.WindowWidth / tileWidth, ScreenManager.WindowHeight / tileHeight)
+        public Camera(int width, int height, int tileWidth, int tileHeight, Map map)
+            : base(0, 0, width / tileWidth, height / tileHeight)
         {
             this.map = map;
             this.tileWidth = tileWidth;
             this.tileHeight = tileHeight;
-            this.leftoverSpaceX = ScreenManager.WindowWidth % this.tileWidth;
-            this.leftoverSpaceY = ScreenManager.WindowHeight % this.tileHeight;
+            this.leftoverSpaceX = width % this.tileWidth;
+            this.leftoverSpaceY = height % this.tileHeight;
             ActiveEnhancedMapTiles = new List<EnhancedMapTile>();
             ActiveNPCs = new List<NPC>();
             ActiveTriggers = new List<Trigger>();

--- a/Monogame-RPG-Engine/src/Engine/Scene/MapCore/Map.cs
+++ b/Monogame-RPG-Engine/src/Engine/Scene/MapCore/Map.cs
@@ -143,6 +143,9 @@ namespace Engine.Scene.MapCore
         // reference to current player
         public Player Player { get; set; }
 
+        private int cameraWidth;
+        private int cameraHeight;
+
         public int WidthPixels
         {
             get
@@ -162,18 +165,20 @@ namespace Engine.Scene.MapCore
         // instance of content loader to allow maps to load their own content
         public ContentLoader ContentLoader { get; private set; }
 
-        public Map(string mapFileName, Tileset tileset, ContentLoader contentLoader)
+        public Map(string mapFileName, Tileset tileset, int cameraWidth, int cameraHeight, ContentLoader contentLoader)
         {
             MapFileName = mapFileName;
             Tileset = tileset;
             ContentLoader = contentLoader;
+            this.cameraWidth = cameraWidth;
+            this.cameraHeight = cameraHeight;
             SetupMap();
             this.startBoundX = 0;
             this.startBoundY = 0;
             EndBoundX = Width * tileset.SpriteWidthScaled;
             EndBoundY = Height * tileset.SpriteHeightScaled;
-            this.xMidPoint = ScreenManager.WindowWidth / 2;
-            this.yMidPoint = ScreenManager.WindowHeight / 2;
+            this.xMidPoint = cameraWidth / 2;
+            this.yMidPoint = cameraHeight / 2;
             PlayerStartTile = new Point(0, 0);
         }
 
@@ -207,7 +212,7 @@ namespace Engine.Scene.MapCore
 
             this.LoadScripts();
 
-            Camera = new Camera(0, 0, Tileset.SpriteWidthScaled, Tileset.SpriteHeightScaled, this);
+            Camera = new Camera(cameraWidth, cameraHeight, Tileset.SpriteWidthScaled, Tileset.SpriteHeightScaled, this);
         }
 
         // reads in a map file to create the map's tilemap

--- a/Monogame-RPG-Engine/src/Engine/Scene/MapCore/Map.cs
+++ b/Monogame-RPG-Engine/src/Engine/Scene/MapCore/Map.cs
@@ -172,8 +172,8 @@ namespace Engine.Scene.MapCore
             this.startBoundY = 0;
             EndBoundX = Width * tileset.SpriteWidthScaled;
             EndBoundY = Height * tileset.SpriteHeightScaled;
-            this.xMidPoint = ScreenManager.ScreenWidth / 2;
-            this.yMidPoint = ScreenManager.ScreenHeight / 2;
+            this.xMidPoint = ScreenManager.WindowWidth / 2;
+            this.yMidPoint = ScreenManager.WindowHeight / 2;
             PlayerStartTile = new Point(0, 0);
         }
 


### PR DESCRIPTION
Each screen class now has a built-in render target that it draws to, and then that render target as a whole is drawn.

This is to allow a screen to have proper "bounds", meaning screens now actually serve more of a purpose than just separation of code like they were doing before. They are now a proper organizational construct. This has many added benefits, such as being able to apply an effect to an entire screen, or being able to translate an entire screen across the x/y axis.

Additionally, the camera class was updated to no longer by default set itself to the window bounds. Now the width and height of the camera must be passed in. This makes it really easy to set how large the camera should be while ensuring the player will always stay centered and follow normal logic. With the render target changes, this also makes it really easy to make a camera/map of any pixel width/height and then place it where you want on the screen.

As a side effect of this update, all screens now override a protected Draw method for detailing their assets to draw (as opposed to a public method), and then the Render method on a screen class is what needs to be called to actually draw the content to the screen.

As a fail safe, all screens have the option to not use the render target by setting its `UseRenderTarget` variable to `false`. This is currently done in the `ScreenCoordinator` class since that class doesn't need a render target, as its entire purpose is to match the size of the window. By default, screen bounds are set to be the size of the entire window, but any Screen can modify its own bounds by setting its `ScreenX`, `ScreenY`, `ScreenWidth`, and `ScreenHeight` properties (or by calling `SetScreenBounds` method to do it all at once). While I know it's not DRY to prefix these vars with "Screen" when they are already in the `Screen` class, but trust me it was getting really confusing trying to discern where the "X" or "Width" variables were coming from in a screen subclass. Also it is not unreasonable for someone to create location variables in a screen class named "x" or "y", so I just don't want to cause any mixups of accidentally overriding the core Screen variables and causing the entire engine to fail to render.......